### PR TITLE
Add a regex to allow Server with "Master :" in Infra Status also get

### DIFF
--- a/tasks/confirm_primary_server.rb
+++ b/tasks/confirm_primary_server.rb
@@ -15,8 +15,8 @@ def get_primary_hostname(ignore_infra_status_error)
     end
   end
   output.each_line do |line|
-    if line.match(/^Primary: /)
-      primary = line.gsub(/^Primary: /, '').lstrip.rstrip
+    if line.match(/^Primary: |^Master: /)
+      primary = line.gsub(/^Primary: |^Master: /, '').lstrip.rstrip
       return primary
     end
   end


### PR DESCRIPTION
recognised as a Puppet Primary host. E.g. in PE 2021.3.0 Signed-off-by: Hoo Sooyean (何書淵)
<60423341+sooyean-hoo@users.noreply.github.com>
Signed-off-by: Hoo Sooyean 何書淵 <Sooyean.hoo@puppet.com>